### PR TITLE
[Docker] Dockerfile for a prisma CLI with turntable code.

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,2 @@
+node_modules
+

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,17 @@
+FROM node:8
+
+RUN mkdir /app
+WORKDIR /app
+
+COPY package.json .
+
+RUN npm i --loglevel warn --no-progress
+
+COPY bin bin
+COPY server server
+COPY prisma.yml datamodel.graphql schema.graphql .graphqlconfig.yaml ./
+
+# Can't do this without a running server already?
+#RUN npm run codegen && npm run compile
+
+CMD bash


### PR DESCRIPTION
Needed dockerized version of turntable. Prisma wants you to use their proprietary image, so I couldn't bundle a real "server" instance. Instead I just dockerized the prisma CLI with turntable schema, etc. Vinyl uses this in its CI.