### PR TITLE
Added cascading deletes

### DIFF
--- a/datamodel.graphql
+++ b/datamodel.graphql
@@ -7,6 +7,8 @@ type Track {
   id: ID! @unique
   info: TrackInfo!
   playlist: Playlist!
+  controls: [RemoteControl!]!
+    @relation(name: "ControlsBySong", onDelete: CASCADE)
 }
 
 type TrackInfo {
@@ -32,6 +34,6 @@ enum ControlAction {
 
 type RemoteControl {
   id: ID! @unique
-  song: Track!
+  song: Track! @relation(name: "ControlsBySong")
   action: ControlAction!
 }


### PR DESCRIPTION
The reason deletes weren't working is that `Tracks` are linked to `RemoteControls` now, and deleting a `Track` would leave all the `RemoteControls` for that song with an empty reference.

This PR updates the schema to add [cascading deletes](https://github.com/prisma/prisma/issues/1262), so that when you delete a song, all the related `RemoteControl`s get deleted too.